### PR TITLE
Update documentation for h5py API schism

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,13 +30,16 @@ We recommand the use [Miniconda](https://conda.io/miniconda.html) to install all
 After installing Miniconda, simply run (this may take about 5-10 minutes),
 
 
-    conda install python=3.6 numpy theano=1.0.3 keras=2.2.4 scikit-learn Biopython h5py
+    conda install python=3.6 numpy theano=1.0.3 keras=2.2.4 scikit-learn Biopython "h5py<3"
     
 or create a virtual environment 
 
-    conda create --name dvf python=3.6 numpy theano=1.0.3 keras=2.2.4 scikit-learn Biopython h5py
+    conda create --name dvf python=3.6 numpy theano=1.0.3 keras=2.2.4 scikit-learn Biopython "h5py<3"
     source activate dvf
 
+On some architectures, [h5py may not be able to create lock files.](https://github.com/nanoporetech/medaka/issues/240). A workaround for this issue is to disable file locking for h5py.
+
+    export HDF5_USE_FILE_LOCKING='FALSE'
 
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ or create a virtual environment
     conda create --name dvf python=3.6 numpy theano=1.0.3 keras=2.2.4 scikit-learn Biopython "h5py<3"
     source activate dvf
 
-On some architectures, [h5py may not be able to create lock files.](https://github.com/nanoporetech/medaka/issues/240). A workaround for this issue is to disable file locking for h5py.
+On some architectures, [h5py may not be able to create lock files](https://github.com/nanoporetech/medaka/issues/240). A workaround for this issue is to disable file locking for h5py.
 
     export HDF5_USE_FILE_LOCKING='FALSE'
 


### PR DESCRIPTION
Since the documentation for DeepVirFinder was released, a new version of h5py has been released that breaks API compatibility with previous versions. This PR updates the documentation to suggest pinning h5py below version 3, and adds a workaround for running dvf on architectures where file locking does not work as expected.