### PR TITLE
Prediction refactoring

### DIFF
--- a/compare_results.py
+++ b/compare_results.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+# @Author: jsgounot
+# @Date:   2022-01-05 10:54:42
+# @Last Modified by:   jsgounot
+# @Last Modified time: 2022-01-05 10:54:51
+
+import sys
+
+f1, f2 = sys.argv[1], sys.argv[2]
+
+def load_result(fname):
+	r = {}
+	with open(fname) as f:
+		for idx, line in enumerate(f):
+			if idx == 0:
+				continue
+
+			line = line.strip().split()
+			name, res = line[0], tuple(line[1:])
+			r[name] = res
+
+	return r
+
+r1 = load_result(f1)
+r2 = load_result(f2)
+
+# assert we have the same set of names
+assert set(r1) == set(r2)
+
+# assert we have the same results
+for k1, v1 in r1.items():
+	assert v1 == r2[k1]
+
+print ('Same results')

--- a/dvf.py
+++ b/dvf.py
@@ -2,8 +2,9 @@
 # title             :dvf.py
 # description       :Identifying viral sequences from metagenomic data by deep learning
 # author            :Jie Ren renj@usc.edu
-# date              :20180807
-# version           :1.0
+# corrections       :Jean-Sebastien Gounot jsgounot@gmail.com
+# date              :20210105
+# version           :2.0
 # usage             :python dvf.py -i <path_to_input_fasta> -o <path_to_output_directory>
 # required packages :numpy, theano, keras 
 # conda create -n dvf python=3.6 numpy theano keras scikit-learn Biopython
@@ -11,217 +12,210 @@
 
 
 #### Step 0: pass arguments into the program ####
-import os, sys, optparse, warnings
+import os, sys, time
+import optparse, warnings
+import random
 
-prog_base = os.path.split(sys.argv[0])[1]
-parser = optparse.OptionParser()
-parser.add_option("-i", "--in", action = "store", type = "string", dest = "input_fa", 
-                  help = "input fasta file")
-parser.add_option("-m", "--mod", action = "store", type = "string", dest = "modDir",
-									default=os.path.join(os.path.dirname(os.path.abspath(__file__)), "models"), 
-                  help = "model directory (default ./models)")
-parser.add_option("-o", "--out", action = "store", type = "string", dest = "output_dir",
-									default='./', help = "output directory")
-parser.add_option("-l", "--len", action = "store", type = "int", dest = "cutoff_len",
-									default=1, help = "predict only for sequence >= L bp (default 1)")
-parser.add_option("-c", "--core", action = "store", type = "int", dest = "core_num",
-									default=1, help = "number of parallel cores (default 1)")
-
-(options, args) = parser.parse_args()
-if (options.input_fa is None) :
-	sys.stderr.write(prog_base + ": ERROR: missing required command-line argument")
-	filelog.write(prog_base + ": ERROR: missing required command-line argument")
-	parser.print_help()
-	sys.exit(0)
-
-input_fa = options.input_fa
-if options.output_dir != './' :
-  output_dir = options.output_dir
-else :
-  output_dir = os.path.dirname(os.path.abspath(input_fa))
-if not os.path.exists(output_dir):
-    os.makedirs(output_dir)
-cutoff_len = options.cutoff_len
-core_num = options.core_num
-
-
-#### Step 0: import keras libraries ####
 import h5py, multiprocessing
 import numpy as np
 
 os.environ['KERAS_BACKEND'] = 'theano'
 import keras
 from keras.models import load_model
-#sys.setrecursionlimit(10000000)
-#os.environ['THEANO_FLAGS'] = "floatX=float32,openmp=True" 
-#os.environ['THEANO_FLAGS'] = "mode=FAST_RUN,device=gpu0,floatX=float32" 
-#os.environ['OMP_NUM_THREADS'] = str(multiprocessing.cpu_count())
 
+class FRecord():
 
-#### Step 0: function for encoding sequences into matrices of size 4 by n ####
-def encodeSeq(seq) : 
-    seq_code = list()
-    for pos in range(len(seq)) :
-        letter = seq[pos]
-        if letter in ['A', 'a'] :
-            code = [1,0,0,0]
-        elif letter in ['C', 'c'] :
-            code = [0,1,0,0]
-        elif letter in ['G', 'g'] :
-            code = [0,0,1,0]
-        elif letter in ['T', 't'] :
-            code = [0,0,0,1]
-        else :
-            code = [1/4, 1/4, 1/4, 1/4]
-        seq_code.append(code)
-    return seq_code 
-    
-    
-complement = {'A': 'T', 'C': 'G', 'G': 'C', 'T': 'A', 'N': 'N'}
-#seq = "TCGGGCCC"
-#reverse_complement = "".join(complement.get(base, base) for base in reversed(seq))
+    COMPLEMENT = {'A': 'T', 'C': 'G', 'G': 'C', 'T': 'A', 'N': 'N'}
+
+    ENCODING = {
+        'A': [1,0,0,0],
+        'C': [0,1,0,0],
+        'G': [0,0,1,0],
+        'T': [0,0,0,1],
+    }
+
+    MISSING = [1/4, 1/4, 1/4, 1/4]
+
+    def __init__(self, name, record):
+        self.name = name
+        self.record = record
+
+    def seqlen(self):
+        return len(self.record)
+
+    def ncount(self):
+        return self.record.count("N")
+
+    def complement(self):
+        nrecord = ''.join(FRecord.COMPLEMENT.get(base, base) for base in reversed(self.record))
+        return FRecord(self.name, nrecord)
+
+    def encode(self):
+        record = self.record.upper()
+        return np.array([[FRecord.ENCODING.get(base, FRecord.MISSING)
+            for base in record]])
+
+    @staticmethod
+    def from_fasta(fname):
+        name, record = None, None
+        with open(fname) as f:
+            for line in f:
+                line = line.strip()
+                if line.startswith('>'):
+                    if name and record:
+                        yield FRecord(name, record)
+
+                    name = line[1:]
+                    record = ''
+
+                else:
+                    record += line
+
+        yield FRecord(name, record)
+
+def load_models(modDir):
+    #### Step 1: load model ####
+    print("1. Loading Models. Model directory {}".format(modDir))
+
+    modDict = {}
+    nullDict = {}
+
+    warnings.filterwarnings('ignore', 'Error in loading the saved optimizer ')
+
+    for contigLengthk in ['0.15', '0.3', '0.5', '1'] :
+        modPattern = 'model_siamese_varlen_' + contigLengthk + 'k'
+        modName = [x for x in os.listdir(modDir) if modPattern in x and x.endswith(".h5")][0]
+        modDict[contigLengthk] = load_model(os.path.join(modDir, modName))
   
-    
-#### Step 0: function for predicting viral score using the trained model ####
-def pred(ID) :
-    codefw = code[ID]
-    codebw = codeR[ID]
-    head = seqname[ID]
-    
-    #print('predicting '+head)
-    seqL = len(codefw)
-    
-    if seqL < 300 :
-      model = modDict['0.15']
-      null = nullDict['0.15']
+        ypred_file = [x for x in os.listdir(modDir) if modPattern in x and "Y_pred" in x]
+        assert len(ypred_file) == 1
+        ypred_file = os.path.join(modDir, ypred_file[0])
+        ypred = np.loadtxt(ypred_file, delimiter=' ')
+
+        ytrue_file = [x for x in os.listdir(modDir) if modPattern in x and "Y_true" in x]
+        assert len(ytrue_file) == 1
+        ytrue_file = os.path.join(modDir, ytrue_file[0])
+        ytrue = np.loadtxt(ytrue_file, delimiter=' ')
+
+        index_one = np.where(ytrue == 1)[0][0]
+        nullDict[contigLengthk] = ypred[:index_one]        
+
+    return modDict, nullDict
+
+def predict(frecord, modDict, nullDict):
+    seqL = frecord.seqlen()
+
+    if seqL < 300:
+        key = '0.15'
     elif seqL < 500 and seqL >= 300 :
-      model = modDict['0.3']
-      null = nullDict['0.3']
+        key = '0.3'
     elif seqL < 1000 and seqL >= 500 :
-      model = modDict['0.5']
-      null = nullDict['0.5']
+        key = '0.5'
     else :
-      model = modDict['1']
-      null = nullDict['1']
+        key = '1'
     
-    score = model.predict([np.array([codefw]), np.array([codebw])], batch_size=1)
-    pvalue = sum([x>score for x in null])/len(null)
+    model = modDict[key]
+    null = nullDict[key]
+
+    codefw = frecord.encode()
+    codebw = frecord.complement().encode()
+    score = model.predict([codefw, codebw], batch_size=1)
+
+    if score.shape != (1, 1):
+        raise Exception('Uncorrect score shape', score.shape)
     
-    writef = predF.write('\t'.join([head, str(seqL), str(float(score)), str(float(pvalue))])+'\n')
-    flushf = predF.flush()
+    score = float(score)
+    pvalue = len(null[null > score]) / len(null)
+
+    if random.randint(0, 1000) == 1:
+        print ('checking with old pvalue ... ')
+        oldpvalue = sum([x>score for x in null]) / len(null)
+        assert oldpvalue == pvalue
     
-    return [head, float(score), float(pvalue)]
+    return (frecord.name, seqL, score, float(pvalue))
 
+def process(fdata, modDict, nullDict, cutoff_len):
+    print("2. Encoding and Predicting Sequences.")
 
-#### Step 1: load model ####
-print("1. Loading Models.")
-#modDir = os.path.join(os.path.dirname(os.path.abspath(__file__)), "models")
-modDir = options.modDir
-print("   model directory {}".format(modDir))
+    for frecord in fdata:
 
-modDict = {}
-nullDict = {}
-
-warnings.filterwarnings('ignore', 'Error in loading the saved optimizer ')
-
-for contigLengthk in ['0.15', '0.3', '0.5', '1'] :
-  modPattern = 'model_siamese_varlen_'+contigLengthk+'k'
-  modName = [ x for x in os.listdir(modDir) if modPattern in x and x.endswith(".h5") ][0]
-  #model_1000 = load_model(os.path.join(modDir, modName))
-  modDict[contigLengthk] = load_model(os.path.join(modDir, modName))
-  Y_pred_file = [ x for x in os.listdir(modDir) if modPattern in x and "Y_pred" in x ][0]
-  with open(os.path.join(modDir, Y_pred_file)) as f:
-      tmp = [line.split() for line in f][0]
-      Y_pred = [float(x) for x in tmp ]
-  Y_true_file = [ x for x in os.listdir(modDir) if modPattern in x and "Y_true" in x ][0]
-  with open(os.path.join(modDir, Y_true_file)) as f:
-      tmp = [ line.split()[0] for line in f]
-      Y_true = [ float(x) for x in tmp ]   
-  nullDict[contigLengthk] =  Y_pred[:Y_true.index(1)]  
-
-
-#### Step2 : encode sequences in input fasta, and predict scores ####
-
-# clean the output file
-outfile = os.path.join(output_dir, os.path.basename(input_fa)+'_gt'+str(cutoff_len)+'bp_dvfpred.txt')
-predF = open(outfile, 'w')
-writef = predF.write('\t'.join(['name', 'len', 'score', 'pvalue'])+'\n')
-predF.close()
-predF = open(outfile, 'a')
-#flushf = predF.flush()
-
-print("2. Encoding and Predicting Sequences.")
-with open(input_fa, 'r') as faLines :
-    code = []
-    codeR = []
-    seqname = []
-    head = ''
-    lineNum = 0
-    seq = ''
-    flag = 0
-    for line in faLines :
-        #print(line)
-        lineNum += 1
-        if flag == 0 and line[0] == '>' :
-            print("   processing line "+str(lineNum))
-            head = line.strip()[1:]
+        if frecord.seqlen() < cutoff_len:
+            print ('{} does not pass cutoff len ({} - {}), pass ...'.format(frecord.name, frecord.seqlen(), cutoff_len))
             continue
-        elif line[0] != '>' :
-            seq = seq + line.strip()
-            flag += 1
-        elif flag > 0 and line[0] == '>' :
-            countN = seq.count("N")
-            if countN/len(seq) <= 0.3 and len(seq) >= cutoff_len : 
-                codefw = encodeSeq(seq)
-                seqR = "".join(complement.get(base, base) for base in reversed(seq))
-                codebw = encodeSeq(seqR)
-                code.append(codefw)
-                codeR.append(codebw)
-                seqname.append(head)
-                if len(seqname) % 100 == 0 :
-                    print("   processing line "+str(lineNum))
-                    pool = multiprocessing.Pool(core_num)
-                    head, score, pvalue = zip(*pool.map(pred, range(0, len(code))))
-                    pool.close()
-                    
-                    code = []
-                    codeR = []
-                    seqname = []
-            else :
-                if countN/len(seq) > 0.3 :
-                    print("   {} has >30% Ns, skipping it".format(head))
-                # else :
-                #    print("   {} < {}bp, skipping it".format(head, cutoff_len))
-            
-            flag = 0
-            seq = ''
-            head = line.strip()[1:]
 
-    if flag > 0 :
-        countN = seq.count("N")
-        if countN/len(seq) <= 0.3 and len(seq) >= cutoff_len : 
-            codefw = encodeSeq(seq)
-            seqR = "".join(complement.get(base, base) for base in reversed(seq))
-            codebw = encodeSeq(seqR)
-            code.append(codefw)
-            codeR.append(codebw)
-            seqname.append(head)
+        prcN = frecord.ncount() / frecord.seqlen()
+        if prcN > 0.3:
+            print ('{} N percentage to high ({} - 0.3), pass ...'.format(frecord.name, prcN))
+            continue
 
-        print("   processing line "+str(lineNum))
-        pool = multiprocessing.Pool(core_num)
-        head, score, pvalue = zip(*pool.map(pred, range(0, len(code))))
-        pool.close()
+        print ('Predict for {}'.format(frecord.name))
+        yield predict(frecord, modDict, nullDict)
 
-predF.close()
-
-print("3. Done. Thank you for using DeepVirFinder.")
-print("   output in {}".format(outfile))
+def write_output(outfile, results):
+    with open(outfile, 'w') as f:
+        header = '\t'.join(('name', 'len', 'score', 'pvalue')) + '\n'
+        f.write(header)
+        
+        for result in results:
+            result = [str(value) for value in result]
+            f.write('\t'.join(result) + '\n')
 
 
+if __name__ == '__main__':
 
+    start_time = time.time()
 
+    prog_base = os.path.split(sys.argv[0])[1]
+    parser = optparse.OptionParser()
+    
+    parser.add_option("-i", "--in", action = "store", type = "string", dest = "input_fa",
+        help = "input fasta file")
+    
+    parser.add_option("-m", "--mod", action = "store", type = "string", dest = "modDir",
+        default=os.path.join(os.path.dirname(os.path.abspath(__file__)), "models"), 
+        help = "model directory (default ./models)")
+    
+    parser.add_option("-o", "--out", action = "store", type = "string", dest = "output_dir",
+        default='./', help = "output directory")
+    
+    parser.add_option("-l", "--len", action = "store", type = "int", dest = "cutoff_len",
+        default=1, help = "predict only for sequence >= L bp (default 1)")
 
+    parser.add_option("-f", "--flags", action = "store", type = "string", dest = "tflags",
+        default='', help = "theanos flags")
 
+    (options, args) = parser.parse_args()
+    if (options.input_fa is None) :
+        sys.stderr.write(prog_base + ": ERROR: missing required command-line argument")
+        filelog.write(prog_base + ": ERROR: missing required command-line argument")
+        parser.print_help()
+        sys.exit(1)
 
+    input_fa = options.input_fa
 
+    if options.output_dir != './' :
+      output_dir = options.output_dir
+    else :
+      output_dir = os.path.dirname(os.path.abspath(input_fa))
+    
+    if not os.path.exists(output_dir):
+        os.makedirs(output_dir)
+    
+    cutoff_len = options.cutoff_len
 
+    if options.tflags:
+        #os.environ['THEANO_FLAGS'] = "floatX=float32,openmp=True" 
+        #os.environ['THEANO_FLAGS'] = "mode=FAST_RUN,device=gpu0,floatX=float32" 
+        os.environ['THEANO_FLAGS'] = options.tflags
+
+    modDict, nullDict = load_models(options.modDir)
+    fdata = FRecord.from_fasta(input_fa)
+    results = process(fdata, modDict, nullDict, cutoff_len)
+
+    outfile = os.path.join(output_dir, os.path.basename(input_fa) + '_gt' + str(cutoff_len) + 'bp_dvfpred.txt')
+    write_output(outfile, results)
+
+    print("3. Done. Thank you for using DeepVirFinder. Output in {}".format(outfile))
+
+    end_time = time.time()
+    print(end_time - start_time, "seconds")


### PR DESCRIPTION
#### Potential related issues

All issues related to long runtime: #21, #24, #27

#### Description

After spending a day figuring out why the software takes hours to finish on some sequences, I found several issues:

* Most of the software runtime is not linked to prediction but to pvalue calculation. This was previously done using pure python code and could be massively speed up using numpy.
* The multiple CPUs option python `multiprocessing` module sometimes does not work. An issue which might be related to [numpy inference on CPU attribution](https://stackoverflow.com/questions/15639779/why-does-multiprocessing-use-only-a-single-core-after-i-import-numpy). 
* The code is not well written and could be fixed in multiple ways.

#### Pull request description

Complete rewritting of the main `dvf.py` script. This should produce exactly the same results than before. The results order might change however. 

With one core and using the CRC test file, old version took 102 seconds while new one and in 29 seconds, meaning a **3.5 times** improvement. I suspect the improvement to be actually much better than this since half of the time (~ 15 seconds) is used here to load models. New version of the software does not include the multiprocessing step. 

I implement a random check that new pvalue equals old value every 1,000 predictions but this has never been trigger for all my tests.

I added a `compare_results.py` script to compare results regardless of the order.